### PR TITLE
Explicit error messages

### DIFF
--- a/flask_github_signature/__init__.py
+++ b/flask_github_signature/__init__.py
@@ -18,10 +18,11 @@ def compute_signature(secret, payload):
 
 def get_github_signature(req):
     """Extracts Github's payload signature from request's headers."""
-    gh_signature_header = req.headers.get("X-Hub-Signature-256")
-    if gh_signature_header is not None:
+    gh_signature_header = req.headers.get("X-Hub-Signature-256", "")
+    if gh_signature_header and gh_signature_header.startswith("sha256="):
         return gh_signature_header.replace("sha256=", "")
-    return None
+    else:
+        return None
 
 
 def signature_is_valid(a, b):
@@ -37,15 +38,17 @@ def verify_signature(f):
             raise ValueError("No GH_WEBHOOK_SECRET configured.")
         if request.method != "POST":
             return "Signature verification is only supported on POST method!", 400
-        payload = request.get_data()
-        signature_gh = get_github_signature(request)
-        if signature_gh is None:
+        if "X-Hub-Signature-256" not in request.headers:
             return "Missing signature header!", 400
-        else:
+        signature_gh = get_github_signature(request)
+        if signature_gh is not None:
+            payload = request.get_data()
             signature = compute_signature(gh_webhook_secret, payload)
             if signature_is_valid(signature, signature_gh):
                 return f(*args, **kwargs)
             else:
                 return "Signatures didn't match!", 400
+        else:
+            return "Signature content isn't valid!", 400
 
     return decorated_function

--- a/flask_github_signature/__init__.py
+++ b/flask_github_signature/__init__.py
@@ -19,7 +19,7 @@ def compute_signature(secret, payload):
 def get_github_signature(req):
     """Extracts Github's payload signature from request's headers."""
     gh_signature_header = req.headers.get("X-Hub-Signature-256")
-    if req.method == "POST" and gh_signature_header is not None:
+    if gh_signature_header is not None:
         return gh_signature_header.replace("sha256=", "")
     return None
 
@@ -35,6 +35,8 @@ def verify_signature(f):
         gh_webhook_secret = os.environ.get("GH_WEBHOOK_SECRET")
         if not gh_webhook_secret:
             raise ValueError("No GH_WEBHOOK_SECRET configured.")
+        if request.method != "POST":
+            return "Signature verification is only supported on POST method!", 400
         payload = request.get_data()
         signature = compute_signature(gh_webhook_secret, payload)
         signature_gh = get_github_signature(request)

--- a/flask_github_signature/__init__.py
+++ b/flask_github_signature/__init__.py
@@ -40,9 +40,12 @@ def verify_signature(f):
         payload = request.get_data()
         signature = compute_signature(gh_webhook_secret, payload)
         signature_gh = get_github_signature(request)
-        if signature_gh is not None and signature_is_valid(signature, signature_gh):
-            return f(*args, **kwargs)
+        if signature_gh is None:
+            return "Missing signature header!", 400
         else:
-            return "Signatures didn't match!", 400
+            if signature_is_valid(signature, signature_gh):
+                return f(*args, **kwargs)
+            else:
+                return "Signatures didn't match!", 400
 
     return decorated_function

--- a/flask_github_signature/__init__.py
+++ b/flask_github_signature/__init__.py
@@ -38,11 +38,11 @@ def verify_signature(f):
         if request.method != "POST":
             return "Signature verification is only supported on POST method!", 400
         payload = request.get_data()
-        signature = compute_signature(gh_webhook_secret, payload)
         signature_gh = get_github_signature(request)
         if signature_gh is None:
             return "Missing signature header!", 400
         else:
+            signature = compute_signature(gh_webhook_secret, payload)
             if signature_is_valid(signature, signature_gh):
                 return f(*args, **kwargs)
             else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -111,7 +111,7 @@ class TestViewDecorator(unittest.TestCase):
 
             message, status_code = fn()
             self.assertEqual(status_code, 400)
-            self.assertEqual(message, "Signatures didn't match!")
+            self.assertEqual(message, "Signature verification is only supported on POST method!")
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -83,7 +83,7 @@ class TestViewDecorator(unittest.TestCase):
 
             message, status_code = fn()
             self.assertEqual(status_code, 400)
-            self.assertEqual(message, "Signatures didn't match!")
+            self.assertEqual(message, "Signature content isn't valid!")
 
     def test_no_gh_header(self):
         headers = {}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,7 +96,7 @@ class TestViewDecorator(unittest.TestCase):
 
             message, status_code = fn()
             self.assertEqual(status_code, 400)
-            self.assertEqual(message, "Signatures didn't match!")
+            self.assertEqual(message, "Missing signature header!")
 
     def test_no_post_method(self):
         headers = {


### PR DESCRIPTION
Even if status code is still `400` with invalid signatures, error messages are more explicit now.